### PR TITLE
chore: remove pre-emptive subnet tagging with cluster name

### DIFF
--- a/vpc/eks/default/stack.yaml
+++ b/vpc/eks/default/stack.yaml
@@ -135,8 +135,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -161,8 +159,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -187,8 +183,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -231,8 +225,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/internal-elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -256,8 +248,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/internal-elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -281,8 +271,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/internal-elb"
           Value: 1
         - Key: "network.nuon.co/domain"

--- a/vpc/eks/multi-nat/stack.yaml
+++ b/vpc/eks/multi-nat/stack.yaml
@@ -135,8 +135,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -161,8 +159,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -187,8 +183,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -231,8 +225,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/internal-elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -256,8 +248,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/internal-elb"
           Value: 1
         - Key: "network.nuon.co/domain"
@@ -281,8 +271,6 @@ Resources:
           Value: !Ref NuonOrgID
         - Key: "app.nuon.co/id"
           Value: !Ref NuonAppID
-        - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          Value: shared
         - Key: "kubernetes.io/role/internal-elb"
           Value: 1
         - Key: "network.nuon.co/domain"


### PR DESCRIPTION
The cluster names are customizable. While this pre-emptive tagging is
usually not a problem, it does interfere with certain infrastructure
comopnents. As a result, we're opting to remove this and explicitly tag
relevant subnets in the sandbox terraform.


### Notes

This only affects installs created with the latest version of this CloudFormation stack. It will not affect existing installs unless they are explicitly updated to use the latest tag of this stack and they reprovision their install. As a result, the risk of service interruption is relatively low. 

If a vendor desires to update an install to the latest version of this stack for whatever reason, they must also use the latest version of the corresponding sandboxes to ensure the sandbox terraform applies the subnet tags to restore cluster connectivity. 