### PR TITLE
fix(asg): remove RunnerInstancePolicyAdmin

### DIFF
--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -92,13 +92,6 @@ Resources:
             Resource: '*'
           Version: "2012-10-17"
         PolicyName: RunnerInstancePolicy
-      - PolicyDocument:
-          Statement:
-          - Action: '*'
-            Effect: Allow
-            Resource: '*'
-          Version: "2012-10-17"
-        PolicyName: RunnerInstancePolicyAdmin
       Tags:
       - Key: nuon_runner_id
         Value:

--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -115,7 +115,7 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       PolicyName:
-        Fn::Sub: nuon-install-${InstallId}-metadata
+        Fn::Sub: ${RunnerId}-runner-instance-metadata
       Roles:
       - Ref: RunnerInstanceRole
       PolicyDocument:
@@ -125,11 +125,6 @@ Resources:
           Action:
           - ec2:DescribeTags
           Resource: "*"
-          Condition:
-            StringEquals:
-              ec2:ResourceTag/Name:
-                Fn::Sub: ${RunnerId}-runner-instance
-
   RunnerLaunchTemplate:
     Properties:
       LaunchTemplateData:


### PR DESCRIPTION
1. removes the `RunnerInstancePolicyAdmin` policy. 
2. removes the condition on the metadata policy to allow the instance to describe its own tags. 