### PR TITLE
chore: ensure we use ClusterName

### DIFF
--- a/vpc/eks/default/stack.yaml
+++ b/vpc/eks/default/stack.yaml
@@ -137,6 +137,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "public"
         - Key: "visibility"
@@ -161,6 +163,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "public"
         - Key: "visibility"
@@ -185,6 +189,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "public"
         - Key: "visibility"
@@ -227,6 +233,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/internal-elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "internal"
         - Key: "visibility"
@@ -250,6 +258,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/internal-elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "internal"
         - Key: "visibility"
@@ -273,6 +283,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/internal-elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "internal"
         - Key: "visibility"

--- a/vpc/eks/multi-nat/stack.yaml
+++ b/vpc/eks/multi-nat/stack.yaml
@@ -137,6 +137,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "public"
         - Key: "visibility"
@@ -161,6 +163,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "public"
         - Key: "visibility"
@@ -185,6 +189,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "public"
         - Key: "visibility"
@@ -227,6 +233,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/internal-elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "internal"
         - Key: "visibility"
@@ -250,6 +258,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/internal-elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "internal"
         - Key: "visibility"
@@ -273,6 +283,8 @@ Resources:
           Value: !Ref NuonAppID
         - Key: "kubernetes.io/role/internal-elb"
           Value: "1"
+        - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+          Value: "shared"
         - Key: "network.nuon.co/domain"
           Value: "internal"
         - Key: "visibility"


### PR DESCRIPTION
### Description

We are able to treat cluster*name as a first class input. As a result, we \_can* resume its use in this template.

However, the sandbox strategy is to read the subnets and tag them, if the cluster name is not already present on the subnets, so this is not necessary, stritly speaking.

We must decide between keeping cluster_name as first class or always using the sandbox module to tag.

The latter is more flexible, but the former may be more correct.

### Commits

- **chore(vpc/eks/multi-nat): ensure cluster name is used**
- **chore(vpc/eks/default): ensure cluster name is used**
