### PR TITLE
fix: ensure the runner asg instances use IMDSv2

### DIFF
--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -43,6 +43,10 @@ Parameters:
 
 Resources:
   RunnerAutoScalingGroup:
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
+        MinInstancesInService: 0
     Properties:
       LaunchTemplate:
         LaunchTemplateId:

--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -128,6 +128,9 @@ Resources:
   RunnerLaunchTemplate:
     Properties:
       LaunchTemplateData:
+        MetadataOptions:
+          HttpTokens: required
+          HttpEndpoint: enabled
         BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:


### PR DESCRIPTION
### Description 

 the runner asg instances should use IMDSv2. this change configures the launch template appropriately. 