### PR TITLE
feat(runner/asg): support env vars in runner asg lg user data

### DIFF
--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -19,9 +19,9 @@ Parameters:
     Type: String
     Description: URL for the init script that is added to the use data for the Runner ASG VM instances.
     Default: https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init.sh
-  RunnerEnvExports:
+  RunnerEnvVars:
     Type: String
-    Description: Optional newline-delimited shell export statements to inject into runner user data before init script execution.
+    Description: Optional newline-delimited shell export statements to inject into runner user data before init script execution. e.g. `export FOO=BAR\nexport MOO=COW`.
     Default: ""
   InstanceType:
     Type: String
@@ -43,10 +43,10 @@ Parameters:
     MaxValue: 100
 
 Conditions:
-  HasRunnerEnvExports:
+  HasRunnerEnvVars:
     Fn::Not:
     - Fn::Equals:
-      - Ref: RunnerEnvExports
+      - Ref: RunnerEnvVars
       - ""
 
 Resources:
@@ -198,8 +198,8 @@ Resources:
             - "\n"
             - - "#!/bin/bash"
               - Fn::If:
-                - HasRunnerEnvExports
-                - Ref: RunnerEnvExports
+                - HasRunnerEnvVars
+                - Ref: RunnerEnvVars
                 - Ref: AWS::NoValue
               - Fn::Sub: curl ${RunnerInitScriptUrl} | bash
       LaunchTemplateName:

--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -19,6 +19,10 @@ Parameters:
     Type: String
     Description: URL for the init script that is added to the use data for the Runner ASG VM instances.
     Default: https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init.sh
+  RunnerEnvExports:
+    Type: String
+    Description: Optional newline-delimited shell export statements to inject into runner user data before init script execution.
+    Default: ""
   InstanceType:
     Type: String
     Description: EC2 instance type for the runner
@@ -37,6 +41,13 @@ Parameters:
     Default: 30
     MinValue: 8
     MaxValue: 100
+
+Conditions:
+  HasRunnerEnvExports:
+    Fn::Not:
+    - Fn::Equals:
+      - Ref: RunnerEnvExports
+      - ""
 
 Resources:
   RunnerAutoScalingGroup:
@@ -183,9 +194,14 @@ Resources:
               Fn::Sub: ${RunnerId}-runner-eni
         UserData:
           Fn::Base64:
-            Fn::Sub: |
-              #!/bin/bash
-              curl ${RunnerInitScriptUrl} | bash
+            Fn::Join:
+            - "\n"
+            - - "#!/bin/bash"
+              - Fn::If:
+                - HasRunnerEnvExports
+                - Ref: RunnerEnvExports
+                - Ref: AWS::NoValue
+              - Fn::Sub: curl ${RunnerInitScriptUrl} | bash
       LaunchTemplateName:
         Fn::Sub: ${AWS::StackName}-runner
     Type: AWS::EC2::LaunchTemplate


### PR DESCRIPTION
this way init script has access to user-configured `[env_vars]` in
`runner.toml`.

this change is fully backwards compatible.
