### PR TITLE
feat: new vpc stack no egress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+*.zip
+
+# Created by https://www.toptal.com/developers/gitignore/api/osx,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=osx,vim
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/osx,vim

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,3 +8,15 @@ Use the aws-cli to validate cloudformation templates. Useful for identifying err
 
 Use the python cfn library to validate cloudformation templates. Necessaery to identify duplicate key errors which may
 pass the aws cli check, but cause issues in ctl-api when the template is parsed.
+
+### inspect_egress_domains.py
+
+Inspect a domain or URL and print the `EgressAllowedDomains` values that should be added for the firewall-enabled VPC
+stacks in this repository.
+
+Examples:
+
+```bash
+uv run scripts/inspect_egress_domains.py aws.github.io
+uv run scripts/inspect_egress_domains.py https://aws.github.io/eks-charts/index.yaml
+```

--- a/scripts/inspect_egress_domains.py
+++ b/scripts/inspect_egress_domains.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "dnspython>=2.6.1",
+#     "httpx>=0.27.0",
+#     "PyYAML>=6.0.1",
+# ]
+# ///
+"""
+Inspect a domain or URL and suggest `EgressAllowedDomains` entries.
+
+This is designed for the VPC firewall stacks in this repository, which set
+`FirewallDomainRedirectionAction: TRUST_REDIRECTION_DOMAIN` on the ALLOW rule.
+Because of that, DNS CNAME redirection targets are described but not added to
+the recommended allowlist by default. HTTP redirects and Helm package hosts are
+included because clients will query those hostnames directly.
+
+Examples:
+    uv run scripts/inspect_egress_domains.py aws.github.io
+    uv run scripts/inspect_egress_domains.py https://aws.github.io/eks-charts/index.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import dns.exception
+import dns.resolver
+import httpx
+import yaml
+
+
+MAX_REDIRECTS = 10
+MAX_BODY_BYTES = 1_000_000
+USER_AGENT = "nuon-egress-domain-inspector/1.0"
+
+
+@dataclass
+class DnsInspection:
+    queried_host: str
+    cname_chain: list[str] = field(default_factory=list)
+    ipv4: list[str] = field(default_factory=list)
+    ipv6: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class HttpHop:
+    url: str
+    status_code: int | None
+    location: str | None = None
+    content_type: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class HelmInspection:
+    package_hosts: list[str] = field(default_factory=list)
+    metadata_hosts: list[str] = field(default_factory=list)
+    chart_count: int = 0
+    version_count: int = 0
+    error: str | None = None
+
+
+def normalize_host(host: str | None) -> str | None:
+    if not host:
+        return None
+    return host.rstrip(".").lower()
+
+
+def ordered_unique(values: Iterable[str]) -> list[str]:
+    seen: dict[str, None] = {}
+    for value in values:
+        normalized = normalize_host(value)
+        if normalized:
+            seen.setdefault(normalized, None)
+    return list(seen.keys())
+
+
+def normalize_target(target: str) -> tuple[str, str]:
+    parsed = urlparse(target)
+    if parsed.scheme:
+        host = normalize_host(parsed.hostname)
+        if not host:
+            raise ValueError(f"Unable to determine hostname from target: {target}")
+        return target, host
+
+    host = normalize_host(target)
+    if not host:
+        raise ValueError(f"Unable to determine hostname from target: {target}")
+    return f"https://{host}/", host
+
+
+def resolve_record(host: str, rdtype: str) -> list[str]:
+    try:
+        answers = dns.resolver.resolve(host, rdtype)
+    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.exception.Timeout):
+        return []
+    return [normalize_host(str(answer)) or str(answer) for answer in answers]
+
+
+def inspect_dns(host: str) -> DnsInspection:
+    inspection = DnsInspection(queried_host=host)
+    current = host
+    visited = {host}
+
+    for _ in range(10):
+        targets = resolve_record(current, "CNAME")
+        if not targets:
+            break
+
+        next_host = targets[0]
+        inspection.cname_chain.append(next_host)
+
+        if next_host in visited:
+            inspection.errors.append(f"CNAME loop detected at {next_host}")
+            break
+
+        visited.add(next_host)
+        current = next_host
+
+    inspection.ipv4 = resolve_record(current, "A")
+    inspection.ipv6 = resolve_record(current, "AAAA")
+    if not inspection.ipv4 and not inspection.ipv6:
+        inspection.errors.append("No A or AAAA answers returned")
+
+    return inspection
+
+
+def fetch_url_chain(url: str, timeout: float) -> tuple[list[HttpHop], bytes, str | None]:
+    chain: list[HttpHop] = []
+    current_url = url
+    body = b""
+    final_content_type: str | None = None
+
+    with httpx.Client(
+        headers={"User-Agent": USER_AGENT},
+        follow_redirects=False,
+        timeout=httpx.Timeout(timeout),
+    ) as client:
+        for _ in range(MAX_REDIRECTS + 1):
+            try:
+                with client.stream("GET", current_url) as response:
+                    location = response.headers.get("location")
+                    content_type = response.headers.get("content-type")
+                    hop = HttpHop(
+                        url=current_url,
+                        status_code=response.status_code,
+                        location=location,
+                        content_type=content_type,
+                    )
+                    chain.append(hop)
+
+                    if response.is_redirect and location:
+                        current_url = urljoin(current_url, location)
+                        continue
+
+                    final_content_type = content_type
+                    for chunk in response.iter_bytes():
+                        body += chunk
+                        if len(body) >= MAX_BODY_BYTES:
+                            body = body[:MAX_BODY_BYTES]
+                            break
+                    break
+            except httpx.HTTPError as exc:
+                chain.append(HttpHop(url=current_url, status_code=None, error=str(exc)))
+                break
+
+    return chain, body, final_content_type
+
+
+def extract_url_hosts(values: Iterable[str]) -> list[str]:
+    hosts: list[str] = []
+    for value in values:
+        parsed = urlparse(value)
+        if parsed.scheme and parsed.hostname:
+            host = normalize_host(parsed.hostname)
+            if host:
+                hosts.append(host)
+    return ordered_unique(hosts)
+
+
+def inspect_helm_index(body: bytes) -> HelmInspection | None:
+    text = body.decode("utf-8", errors="replace")
+    if "entries:" not in text:
+        return None
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return HelmInspection(error=f"Unable to parse YAML: {exc}")
+
+    if not isinstance(data, dict) or not isinstance(data.get("entries"), dict):
+        return None
+
+    inspection = HelmInspection()
+    package_hosts: list[str] = []
+    metadata_hosts: list[str] = []
+
+    entries: dict[str, Any] = data["entries"]
+    inspection.chart_count = len(entries)
+    for versions in entries.values():
+        if not isinstance(versions, list):
+            continue
+        inspection.version_count += len(versions)
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            package_hosts.extend(extract_url_hosts(version.get("urls", [])))
+            metadata_hosts.extend(extract_url_hosts(version.get("sources", [])))
+            metadata_hosts.extend(extract_url_hosts([version.get("home", "")]))
+            metadata_hosts.extend(extract_url_hosts([version.get("icon", "")]))
+
+    inspection.package_hosts = ordered_unique(package_hosts)
+    inspection.metadata_hosts = ordered_unique(metadata_hosts)
+    return inspection
+
+
+def fallback_http_if_needed(url: str, timeout: float) -> tuple[str, list[HttpHop], bytes, str | None]:
+    chain, body, content_type = fetch_url_chain(url, timeout)
+    if chain and chain[-1].error and url.startswith("https://"):
+        fallback_url = "http://" + url[len("https://") :]
+        fallback_chain, fallback_body, fallback_content_type = fetch_url_chain(fallback_url, timeout)
+        if fallback_chain and not fallback_chain[-1].error:
+            return fallback_url, fallback_chain, fallback_body, fallback_content_type
+    return url, chain, body, content_type
+
+
+def describe_dns(inspection: DnsInspection) -> list[str]:
+    lines = [f"Queried host: {inspection.queried_host}"]
+    if inspection.cname_chain:
+        lines.append("CNAME chain: " + " -> ".join([inspection.queried_host, *inspection.cname_chain]))
+    else:
+        lines.append("CNAME chain: none")
+
+    if inspection.ipv4:
+        lines.append("IPv4 answers: " + ", ".join(inspection.ipv4))
+    if inspection.ipv6:
+        lines.append("IPv6 answers: " + ", ".join(inspection.ipv6))
+    for error in inspection.errors:
+        lines.append(f"DNS note: {error}")
+    return lines
+
+
+def describe_http(chain: list[HttpHop]) -> list[str]:
+    if not chain:
+        return ["No HTTP response captured."]
+
+    lines: list[str] = []
+    for hop in chain:
+        if hop.error:
+            lines.append(f"{hop.url} -> ERROR: {hop.error}")
+            continue
+
+        line = f"{hop.url} -> {hop.status_code}"
+        if hop.location:
+            line += f" -> {urljoin(hop.url, hop.location)}"
+        lines.append(line)
+
+    redirect_hosts = ordered_unique(
+        urlparse(urljoin(hop.url, hop.location)).hostname
+        for hop in chain
+        if hop.location
+    )
+    if redirect_hosts:
+        lines.append("HTTP redirect hosts requiring explicit allow entries: " + ", ".join(redirect_hosts))
+    else:
+        lines.append("HTTP redirect hosts requiring explicit allow entries: none")
+    return lines
+
+
+def build_recommendations(
+    start_host: str,
+    chain: list[HttpHop],
+    helm: HelmInspection | None,
+) -> tuple[list[str], dict[str, str]]:
+    recommendations: list[str] = []
+    reasons: dict[str, str] = {}
+
+    def add(host: str | None, reason: str) -> None:
+        normalized = normalize_host(host)
+        if not normalized:
+            return
+        if normalized not in reasons:
+            recommendations.append(normalized)
+            reasons[normalized] = reason
+
+    add(start_host, "Original hostname queried by the workload")
+
+    for hop in chain:
+        if hop.location:
+            redirect_host = normalize_host(urlparse(urljoin(hop.url, hop.location)).hostname)
+            add(redirect_host, "HTTP redirect target host")
+
+    if helm:
+        for host in helm.package_hosts:
+            add(host, "Helm chart package host from index.yaml urls")
+
+    return recommendations, reasons
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", help="Domain or URL to inspect")
+    parser.add_argument("--timeout", type=float, default=15.0, help="Network timeout in seconds (default: 15)")
+    args = parser.parse_args()
+
+    try:
+        url, start_host = normalize_target(args.target)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    url, chain, body, content_type = fallback_http_if_needed(url, args.timeout)
+    dns_inspection = inspect_dns(start_host)
+    helm_inspection = inspect_helm_index(body)
+    recommendations, reasons = build_recommendations(start_host, chain, helm_inspection)
+
+    print("Target")
+    print(f"  Input: {args.target}")
+    print(f"  URL: {url}")
+    print(f"  Host: {start_host}")
+    print()
+
+    print("DNS")
+    for line in describe_dns(dns_inspection):
+        print(f"  {line}")
+    print()
+
+    print("HTTP")
+    for line in describe_http(chain):
+        print(f"  {line}")
+    if content_type:
+        print(f"  Final content-type: {content_type}")
+    print()
+
+    print("Content Inspection")
+    if helm_inspection and not helm_inspection.error:
+        print("  Detected Helm repository index.yaml")
+        print(f"  Charts: {helm_inspection.chart_count}")
+        print(f"  Versions: {helm_inspection.version_count}")
+        print(
+            "  Chart package hosts: "
+            + (", ".join(helm_inspection.package_hosts) if helm_inspection.package_hosts else "none")
+        )
+        print(
+            "  Metadata/reference hosts not added automatically: "
+            + (", ".join(helm_inspection.metadata_hosts) if helm_inspection.metadata_hosts else "none")
+        )
+    elif helm_inspection and helm_inspection.error:
+        print(f"  Helm index parsing failed: {helm_inspection.error}")
+    else:
+        print("  No Helm index detected.")
+    print()
+
+    print("Recommended EgressAllowedDomains Entries")
+    for host in recommendations:
+        print(f"  - {host}: {reasons[host]}")
+    print()
+
+    print("Parameter Value")
+    print("  " + ",".join(recommendations))
+    print()
+
+    print("Notes")
+    print(
+        "  - This repository's firewall templates use TRUST_REDIRECTION_DOMAIN, so DNS CNAME targets are described above"
+    )
+    print("    but are not added automatically to the allowlist recommendation.")
+    print("  - HTTP redirect hosts are added because clients will resolve and request those hosts directly.")
+    print("  - Helm chart package hosts from index.yaml urls are added because Helm downloads those archives directly.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vpc/eks/README.md
+++ b/vpc/eks/README.md
@@ -1,0 +1,13 @@
+# VPC stack templates for EKS
+
+These VPC CF Stacks have a parameter `ClusterName`. Typically, a vendor defines an input `cluster_name` which is then
+passed to the stack automatically by the nuon control plane. This way, the VPC is pre-tagged for use by the cluster.
+
+This is maintained for historical purposes. At the time of writing, the tagging is managed by the eks sandbox terraform
+meaning we no longer have an explicit need for the automated tagging that takes place here.
+
+Tagging in the terraform is preferable and sometimes required as is in the case when the eks sandboxes are deployed to
+an existing vpc.
+
+The EKS VPC templates also support the optional Route 53 DNS firewall used by the non-EKS VPC stacks. Set
+`EnableFirewall=true` and provide `EgressAllowedDomains` to allowlist outbound DNS when needed.

--- a/vpc/eks/default/README.md
+++ b/vpc/eks/default/README.md
@@ -1,22 +1,39 @@
 # VPC for EKS
 
+<!-- cf-doc md stack.yaml -->
+
 Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az), a Nat gateway, and an internet
-gateway. The subnets are tagged for use by EKS (alb ingress controller). To control the number of public or private
-subnets, remove the subnets (starting with 3 then 2). Will create at least one subnet.
+gateway. The subnets are tagged for use by EKS (alb ingress controller). Optionally deploys a Route 53 DNS Firewall
+(EnableFirewall=true) that blocks all outbound DNS unless domains are explicitly allowed via the EgressAllowedDomains
+parameter. To control the number of public or private subnets, remove the subnets (starting with 3 then 2). Will create
+at least one subnet.
 
 ## Parameters
 
-| Name               | Description                                                                                      |  Type  |     Default     | Allowed Values |
-| ------------------ | ------------------------------------------------------------------------------------------------ | :----: | :-------------: | :------------- |
-| ClusterName        | The name for the EKS Cluster that will be deployed on this VPC.                                  | String |                 |                |
-| NuonInstallID      | The Nuon Install ID; prefixed to resource names.                                                 | String |                 |                |
-| NuonOrgID          | The Nuon Org ID. Used in tags.                                                                   | String |                 |                |
-| NuonAppID          | The Nuon Install ID. Used in tags.                                                               | String |                 |                |
-| VpcCIDR            | Please enter the IP range (CIDR notation) for this VPC.                                          | String |  10.128.0.0/16  |                |
-| PublicSubnet1CIDR  | Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone   | String |  10.128.0.0/26  |                |
-| PublicSubnet2CIDR  | Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone  | String | 10.128.0.64/26  |                |
-| PublicSubnet3CIDR  | Please enter the IP range (CIDR notation) for the public subnet in the third Availability Zone   | String | 10.128.0.128/26 |                |
-| RunnerSubnetCIDR   | Please enter the IP range (CIDR notation) for the dedicated private subnet for the runner.       | String | 10.128.128.0/24 |                |
-| PrivateSubnet1CIDR | Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone  | String | 10.128.130.0/24 |                |
-| PrivateSubnet2CIDR | Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone | String | 10.128.132.0/24 |                |
-| PrivateSubnet3CIDR | Please enter the IP range (CIDR notation) for the private subnet in the third Availability Zone  | String | 10.128.134.0/24 |                |
+| Name                 | Description                                                                                                                   |  Type  |     Default     | Allowed Values |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | :----: | :-------------: | :------------- |
+| ClusterName          | The name for the EKS Cluster that will be deployed on this VPC.                                                               | String |                 |                |
+| EgressAllowedDomains | Comma-delimited list of domains allowed for outbound traffic (e.g. api.nuon.co,.nuon.co). Ignored if EnableFirewall is false. | String |                 |                |
+| EnableFirewall       | Enable Route 53 DNS Firewall to control outbound DNS resolution.                                                              | String |      false      |                |
+| NuonAppID            | The Nuon Install ID. Used in tags.                                                                                            | String |                 |                |
+| NuonInstallID        | The Nuon Install ID; prefixed to resource names.                                                                              | String |                 |                |
+| NuonOrgID            | The Nuon Org ID. Used in tags.                                                                                                | String |                 |                |
+| PrivateSubnet1CIDR   | Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone                               | String | 10.128.130.0/24 |                |
+| PrivateSubnet2CIDR   | Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone                              | String | 10.128.132.0/24 |                |
+| PrivateSubnet3CIDR   | Please enter the IP range (CIDR notation) for the private subnet in the third Availability Zone                               | String | 10.128.134.0/24 |                |
+| PublicSubnet1CIDR    | Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone                                | String |  10.128.0.0/26  |                |
+| PublicSubnet2CIDR    | Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone                               | String | 10.128.0.64/26  |                |
+| PublicSubnet3CIDR    | Please enter the IP range (CIDR notation) for the public subnet in the third Availability Zone                                | String | 10.128.0.128/26 |                |
+| RunnerSubnetCIDR     | Please enter the IP range (CIDR notation) for the dedicated private subnet for the runner.                                    | String | 10.128.128.0/24 |                |
+| VpcCIDR              | Please enter the IP range (CIDR notation) for this VPC.                                                                       | String |  10.128.0.0/16  |                |
+
+## Outputs
+
+| Name                   | Description                                           | Export |
+| ---------------------- | ----------------------------------------------------- | ------ |
+| DnsFirewallRuleGroupId | The DNS Firewall rule group ID.                       |        |
+| PrivateSubnets         | A list of the private subnets.                        |        |
+| PublicSubnets          | A list of the public subnets.                         |        |
+| RunnerSubnet           | The dedicated private subnet for the runner.          |        |
+| SecurityGroupId        | The default security group ID (no egress by default). |        |
+| VPC                    | The VPC.                                              |        |

--- a/vpc/eks/default/stack.yaml
+++ b/vpc/eks/default/stack.yaml
@@ -1,4 +1,10 @@
-Description: Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az), a Nat gateway, and an internet gateway. The subnets are tagged for use by EKS (alb ingress controller). To control the number of public or private subnets, remove the subnets (starting with 3 then 2). Will create at least one subnet.
+Description: >-
+  Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az),
+  a Nat gateway, and an internet gateway. The subnets are tagged for use by EKS (alb ingress
+  controller). Optionally deploys a Route 53 DNS Firewall (EnableFirewall=true) that blocks all
+  outbound DNS unless domains are explicitly allowed via the EgressAllowedDomains parameter. To
+  control the number of public or private subnets, remove the subnets (starting with 3 then 2).
+  Will create at least one subnet.
 
 Parameters:
   ClusterName:
@@ -58,6 +64,19 @@ Parameters:
     Type: String
     Default: 10.128.134.0/24
 
+  EnableFirewall:
+    Description: Enable Route 53 DNS Firewall to control outbound DNS resolution.
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+
+  EgressAllowedDomains:
+    Description: Comma-delimited list of domains allowed for outbound traffic (e.g. api.nuon.co,.nuon.co). Ignored if EnableFirewall is false.
+    Type: String
+    Default: ""
+
 Conditions:
   CreatePublicSubnet2: !Not [!Equals ["", !Ref "PublicSubnet2CIDR"]]
   CreatePublicSubnet3: !Not [!Equals ["", !Ref "PublicSubnet3CIDR"]]
@@ -82,6 +101,15 @@ Conditions:
   CreateOnePrivateSubnets: !And
     - !Not [!Condition CreatePrivateSubnet2]
     - !Not [!Condition CreatePrivateSubnet3]
+
+  FirewallEnabled: !Equals [!Ref EnableFirewall, "true"]
+
+  HasEgressAllowedDomains: !And
+    - !Condition FirewallEnabled
+    - !Not
+      - !Equals
+        - !Ref EgressAllowedDomains
+        - ""
 
 Resources:
   VPC:
@@ -398,6 +426,95 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
       SubnetId: !Ref PrivateSubnet3
 
+  # Security Group: no egress by default
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "${NuonInstallID} default security group"
+      VpcId: !Ref VPC
+      SecurityGroupIngress: []
+      SecurityGroupEgress: []
+      Tags:
+        - Key: Name
+          Value: !Sub ${NuonInstallID}-default-sg
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  # DNS Firewall: block all outbound DNS by default, allow listed domains
+  DnsFirewallAllowList:
+    Type: AWS::Route53Resolver::FirewallDomainList
+    Condition: HasEgressAllowedDomains
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-allow-list
+      Domains: !Split [",", !Ref EgressAllowedDomains]
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  DnsFirewallBlockAll:
+    Type: AWS::Route53Resolver::FirewallDomainList
+    Condition: FirewallEnabled
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-block-all
+      Domains:
+        - "*"
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  DnsFirewallRuleGroup:
+    Type: AWS::Route53Resolver::FirewallRuleGroup
+    Condition: FirewallEnabled
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-dns-firewall
+      FirewallRules:
+        - !If
+          - HasEgressAllowedDomains
+          - Action: ALLOW
+            FirewallDomainListId: !Ref DnsFirewallAllowList
+            FirewallDomainRedirectionAction: TRUST_REDIRECTION_DOMAIN
+            Priority: 100
+          - !Ref AWS::NoValue
+        - Action: BLOCK
+          BlockResponse: NODATA
+          FirewallDomainListId: !Ref DnsFirewallBlockAll
+          Priority: 200
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  DnsFirewallRuleGroupAssociation:
+    Type: AWS::Route53Resolver::FirewallRuleGroupAssociation
+    Condition: FirewallEnabled
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-dns-firewall
+      FirewallRuleGroupId: !Ref DnsFirewallRuleGroup
+      VpcId: !Ref VPC
+      Priority: 101
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
 Outputs:
   VPC:
     Description: The VPC.
@@ -426,3 +543,12 @@ Outputs:
   RunnerSubnet:
     Description: The dedicated private subnet for the runner.
     Value: !Ref RunnerSubnet
+
+  SecurityGroupId:
+    Description: The default security group ID (no egress by default).
+    Value: !Ref SecurityGroup
+
+  DnsFirewallRuleGroupId:
+    Condition: FirewallEnabled
+    Description: The DNS Firewall rule group ID.
+    Value: !Ref DnsFirewallRuleGroup

--- a/vpc/eks/multi-nat/README.md
+++ b/vpc/eks/multi-nat/README.md
@@ -1,33 +1,39 @@
 # VPC for EKS
 
-Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one
-per az), a Nat gateway, and an internet gateway. The subnets are tagged for use
-by EKS (alb ingress controller). To control the number of public or private
-subnets, remove the subnets (starting with 3 then 2). Will create at least one
-subnet.
+<!-- cf-doc md stack.yaml -->
+
+Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az), multiple Nat gateways (one per
+az), and an internet gateway. The subnets are tagged for use by EKS (alb ingress controller). Optionally deploys a Route
+53 DNS Firewall (EnableFirewall=true) that blocks all outbound DNS unless domains are explicitly allowed via the
+EgressAllowedDomains parameter. To control the number of public or private subnets, remove the subnets (starting with 3
+then 2). Will create at least one subnet.
 
 ## Parameters
 
-| Name               | Description                                                                                      |  Type  |     Default     | Allowed Values |
-| ------------------ | ------------------------------------------------------------------------------------------------ | :----: | :-------------: | :------------- |
-| ClusterName        | The name for the EKS Cluster that will be deployed on this VPC.                                  | String |                 |                |
-| NuonInstallID      | The Nuon Install ID; prefixed to resource names.                                                 | String |                 |                |
-| NuonOrgID          | The Nuon Org ID. Used in tags.                                                                   | String |                 |                |
-| NuonAppID          | The Nuon Install ID. Used in tags.                                                               | String |                 |                |
-| VpcCIDR            | Please enter the IP range (CIDR notation) for this VPC.                                          | String |  10.128.0.0/16  |                |
-| PublicSubnet1CIDR  | Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone   | String |  10.128.0.0/26  |                |
-| PublicSubnet2CIDR  | Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone  | String | 10.128.0.64/26  |                |
-| PublicSubnet3CIDR  | Please enter the IP range (CIDR notation) for the public subnet in the third Availability Zone   | String | 10.128.0.128/26 |                |
-| RunnerSubnetCIDR   | Please enter the IP range (CIDR notation) for the dedicated private subnet for the runner.       | String | 10.128.128.0/24 |                |
-| PrivateSubnet1CIDR | Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone  | String | 10.128.130.0/24 |                |
-| PrivateSubnet2CIDR | Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone | String | 10.128.132.0/24 |                |
-| PrivateSubnet3CIDR | Please enter the IP range (CIDR notation) for the private subnet in the third Availability Zone  | String | 10.128.134.0/24 |                |
+| Name                 | Description                                                                                                                   |  Type  |     Default     | Allowed Values |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | :----: | :-------------: | :------------- |
+| ClusterName          | The name for the EKS Cluster that will be deployed on this VPC.                                                               | String |                 |                |
+| EgressAllowedDomains | Comma-delimited list of domains allowed for outbound traffic (e.g. api.nuon.co,.nuon.co). Ignored if EnableFirewall is false. | String |                 |                |
+| EnableFirewall       | Enable Route 53 DNS Firewall to control outbound DNS resolution.                                                              | String |      false      |                |
+| NuonAppID            | The Nuon Install ID. Used in tags.                                                                                            | String |                 |                |
+| NuonInstallID        | The Nuon Install ID; prefixed to resource names.                                                                              | String |                 |                |
+| NuonOrgID            | The Nuon Org ID. Used in tags.                                                                                                | String |                 |                |
+| PrivateSubnet1CIDR   | Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone                               | String | 10.128.130.0/24 |                |
+| PrivateSubnet2CIDR   | Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone                              | String | 10.128.132.0/24 |                |
+| PrivateSubnet3CIDR   | Please enter the IP range (CIDR notation) for the private subnet in the third Availability Zone                               | String | 10.128.134.0/24 |                |
+| PublicSubnet1CIDR    | Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone                                | String |  10.128.0.0/26  |                |
+| PublicSubnet2CIDR    | Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone                               | String | 10.128.0.64/26  |                |
+| PublicSubnet3CIDR    | Please enter the IP range (CIDR notation) for the public subnet in the third Availability Zone                                | String | 10.128.0.128/26 |                |
+| RunnerSubnetCIDR     | Please enter the IP range (CIDR notation) for the dedicated private subnet for the runner.                                    | String | 10.128.128.0/24 |                |
+| VpcCIDR              | Please enter the IP range (CIDR notation) for this VPC.                                                                       | String |  10.128.0.0/16  |                |
 
 ## Outputs
 
-| Name           | Description                                  | Export |
-| -------------- | -------------------------------------------- | ------ |
-| VPC            | The VPC.                                     |        |
-| PublicSubnets  | A list of the public subnets.                |        |
-| PrivateSubnets | A list of the private subnets.               |        |
-| RunnerSubnet   | The dedicated private subnet for the runner. |        |
+| Name                   | Description                                           | Export |
+| ---------------------- | ----------------------------------------------------- | ------ |
+| DnsFirewallRuleGroupId | The DNS Firewall rule group ID.                       |        |
+| PrivateSubnets         | A list of the private subnets.                        |        |
+| PublicSubnets          | A list of the public subnets.                         |        |
+| RunnerSubnet           | The dedicated private subnet for the runner.          |        |
+| SecurityGroupId        | The default security group ID (no egress by default). |        |
+| VPC                    | The VPC.                                              |        |

--- a/vpc/eks/multi-nat/stack.yaml
+++ b/vpc/eks/multi-nat/stack.yaml
@@ -1,4 +1,10 @@
-Description: Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az), a Nat gateway, and an internet gateway. The subnets are tagged for use by EKS (alb ingress controller). To control the number of public or private subnets, remove the subnets (starting with 3 then 2). Will create at least one subnet.
+Description: >-
+  Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az),
+  multiple Nat gateways (one per az), and an internet gateway. The subnets are tagged for use by
+  EKS (alb ingress controller). Optionally deploys a Route 53 DNS Firewall
+  (EnableFirewall=true) that blocks all outbound DNS unless domains are explicitly allowed via the
+  EgressAllowedDomains parameter. To control the number of public or private subnets, remove the
+  subnets (starting with 3 then 2). Will create at least one subnet.
 
 Parameters:
   ClusterName:
@@ -58,6 +64,19 @@ Parameters:
     Type: String
     Default: 10.128.134.0/24
 
+  EnableFirewall:
+    Description: Enable Route 53 DNS Firewall to control outbound DNS resolution.
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+
+  EgressAllowedDomains:
+    Description: Comma-delimited list of domains allowed for outbound traffic (e.g. api.nuon.co,.nuon.co). Ignored if EnableFirewall is false.
+    Type: String
+    Default: ""
+
 Conditions:
   CreatePublicSubnet2: !Not [!Equals ["", !Ref "PublicSubnet2CIDR"]]
   CreatePublicSubnet3: !Not [!Equals ["", !Ref "PublicSubnet3CIDR"]]
@@ -82,6 +101,15 @@ Conditions:
   CreateOnePrivateSubnets: !And
     - !Not [!Condition CreatePrivateSubnet2]
     - !Not [!Condition CreatePrivateSubnet3]
+
+  FirewallEnabled: !Equals [!Ref EnableFirewall, "true"]
+
+  HasEgressAllowedDomains: !And
+    - !Condition FirewallEnabled
+    - !Not
+      - !Equals
+        - !Ref EgressAllowedDomains
+        - ""
 
 Resources:
   VPC:
@@ -505,6 +533,95 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable1
       SubnetId: !Ref RunnerSubnet
 
+  # Security Group: no egress by default
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "${NuonInstallID} default security group"
+      VpcId: !Ref VPC
+      SecurityGroupIngress: []
+      SecurityGroupEgress: []
+      Tags:
+        - Key: Name
+          Value: !Sub ${NuonInstallID}-default-sg
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  # DNS Firewall: block all outbound DNS by default, allow listed domains
+  DnsFirewallAllowList:
+    Type: AWS::Route53Resolver::FirewallDomainList
+    Condition: HasEgressAllowedDomains
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-allow-list
+      Domains: !Split [",", !Ref EgressAllowedDomains]
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  DnsFirewallBlockAll:
+    Type: AWS::Route53Resolver::FirewallDomainList
+    Condition: FirewallEnabled
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-block-all
+      Domains:
+        - "*"
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  DnsFirewallRuleGroup:
+    Type: AWS::Route53Resolver::FirewallRuleGroup
+    Condition: FirewallEnabled
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-dns-firewall
+      FirewallRules:
+        - !If
+          - HasEgressAllowedDomains
+          - Action: ALLOW
+            FirewallDomainListId: !Ref DnsFirewallAllowList
+            FirewallDomainRedirectionAction: TRUST_REDIRECTION_DOMAIN
+            Priority: 100
+          - !Ref AWS::NoValue
+        - Action: BLOCK
+          BlockResponse: NODATA
+          FirewallDomainListId: !Ref DnsFirewallBlockAll
+          Priority: 200
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
+  DnsFirewallRuleGroupAssociation:
+    Type: AWS::Route53Resolver::FirewallRuleGroupAssociation
+    Condition: FirewallEnabled
+    Properties:
+      Name: !Sub ${NuonInstallID}-egress-dns-firewall
+      FirewallRuleGroupId: !Ref DnsFirewallRuleGroup
+      VpcId: !Ref VPC
+      Priority: 101
+      Tags:
+        - Key: "install.nuon.co/id"
+          Value: !Ref NuonInstallID
+        - Key: "org.nuon.co/id"
+          Value: !Ref NuonOrgID
+        - Key: "app.nuon.co/id"
+          Value: !Ref NuonAppID
+
 Outputs:
   VPC:
     Description: The VPC.
@@ -533,3 +650,12 @@ Outputs:
   RunnerSubnet:
     Description: The dedicated private subnet for the runner.
     Value: !Ref RunnerSubnet
+
+  SecurityGroupId:
+    Description: The default security group ID (no egress by default).
+    Value: !Ref SecurityGroup
+
+  DnsFirewallRuleGroupId:
+    Condition: FirewallEnabled
+    Description: The DNS Firewall rule group ID.
+    Value: !Ref DnsFirewallRuleGroup


### PR DESCRIPTION
### Description

Modifies the EKS VPC to add an optional Route53 Firewall whose allowed domains can be configured. 

> [!NOTE]
> This change is designed to be fully backwards compatible. What that means is an app using the previous version should be able to upgrade to the new version with the Route53 firewall and simply not enable it and retain existing functionality. 

### Test Plan

With an existing install, in its `stack.toml`, update the vpc to use this:
```yaml
vpc_nested_stack = https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/vpc/eks/multi-nat/fd-feat-new-vpc-stack-no-egress/stack-081f7db.yaml
```

Ensure the `EgressAllowedDomains` is set and `EnableFirewall` is true

```txt
api.nuon.co,runner.nuon.co,github.com,raw.githubusercontent.com,release-assets.githubusercontent.com,nuon-artifacts.s3.us-west-2.amazonaws.com,amazonlinux-2-repos-us-east-2.s3.us-east-2.amazonaws.com,al2023-repos-us-east-2-de612dc2.s3.dualstack.us-east-2.amazonaws.com,public.ecr.aws,releases.hashicorp.com,registry.terraform.io,*.amazonaws.com,*.us-east-2.amazonaws.com,cdn.amazonlinux.com,retool.com,814326426574.dkr.ecr.us-west-2.amazonaws.com,d2glxqk2uabbnd.cloudfront.net
```
Don't forget any helm repos

```txt
aws.github.io
```

Re-provision and ensure all components deploy. Additional entries may be required on a per-app basis. For example, helm repos or container registries. 