### PR TITLE
fix: remove InstanceType AllowedValues on runner asg

### DIFF
--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -27,14 +27,6 @@ Parameters:
     Type: String
     Description: EC2 instance type for the runner
     Default: t3a.medium
-    AllowedValues:
-    - t3.small
-    - t3.medium
-    - t3a.small
-    - t3a.medium
-    - t3a.large
-    - m5.large
-    - m5a.large
   RootVolumeSize:
     Type: Number
     Description: Size of the root EBS volume in GB


### PR DESCRIPTION
Removes the AllowedValues constraint on the runner ASG InstanceType param. It's an internal param (fed from the parent stack's RunnerInstanceType via Ref), not a user-facing dropdown, so removing it changes no UX — it only stops CREATE_FAILED when a custom type (e.g. t3a.xlarge) is configured. Instance-type control stays on the parent RunnerInstanceType dropdown.