### PR TITLE
chore: modify runner ASG to scope down permissions

### DIFF
--- a/runner/asg/stack.yaml
+++ b/runner/asg/stack.yaml
@@ -1,3 +1,5 @@
+Description: >-
+  Cloudformation Stack for Nuon Runner ASG. Should be used in the runner_nested_template_url field in stack.toml.
 Parameters:
   SubnetId:
     Description: The subnet on which the app will run within the selected VPC.
@@ -26,13 +28,13 @@ Parameters:
   InstanceType:
     Type: String
     Description: EC2 instance type for the runner
-    Default: t3a.medium
+    Default: t3.medium
   RootVolumeSize:
     Type: Number
     Description: Size of the root EBS volume in GB
-    Default: 30
-    MinValue: 8
-    MaxValue: 100
+    Default: 100
+    MinValue: 30
+    MaxValue: 200
 
 Conditions:
   HasRunnerEnvVars:
@@ -86,16 +88,58 @@ Resources:
           Effect: Allow
           Principal:
             Service: ec2.amazonaws.com
-      Description: Instance role for the runner ec2 instance and ASG. Used to assume Provision, Deprovision, and Maintenance roles as needed by the app.
+      Description: Instance role for the runner ec2 instance and ASG. Used to assume Provision, Deprovision, Maintenance, and custom roles as needed by the app.
+      # The SSM agent heartbeat (ssm/ssmmessages/ec2messages) is the only managed
+      # policy attached. Everything else is scoped inline below.
+      ManagedPolicyArns:
+      - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
+      # The runner does all real work by assuming a scoped role, so the instance
+      # role only needs to reach the install's own roles. Every role defined in
+      # permissions/*.toml is named `{{ .nuon.install.id }}-<role>` (provision,
+      # deprovision, maintenance, and the custom roles: acm-operations,
+      # alb-operations, bucket-cleanup), so the install id prefix is the scope.
+      #
+      # A tag condition (iam:ResourceTag/install.nuon.co/id) would be equivalent
+      # in intent, but nuon does not guarantee install tags on the roles it
+      # creates for these definitions -- the name prefix is contractual, the tags
+      # are not, so scoping by name is the safer of the two.
       - PolicyDocument:
-          Statement:
-          - Action:
-            - sts:AssumeIdentity
-            Effect: Allow
-            Resource: '*'
           Version: "2012-10-17"
-        PolicyName: RunnerInstancePolicy
+          Statement:
+          - Sid: AssumeInstallScopedRoles
+            Effect: Allow
+            Action:
+            - sts:AssumeRole
+            - sts:TagSession
+            Resource:
+              Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${InstallId}-*
+        PolicyName: RunnerInstanceAssumeRolePolicy
+      # The cloudwatch agent config written by the runner init script logs to
+      # `runner-$RUNNER_ID` and nothing else. Create + put only; deletes are
+      # denied outright so a compromised runner cannot destroy its own logs (an
+      # explicit Deny cannot be overridden by any later grant).
+      - PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Sid: WriteOwnLogGroup
+            Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            - logs:DescribeLogStreams
+            Resource:
+            - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:runner-${RunnerId}
+            - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:runner-${RunnerId}:*
+          - Sid: DenyLogDeletion
+            Effect: Deny
+            Action:
+            - logs:DeleteLogGroup
+            - logs:DeleteLogStream
+            - logs:DeleteRetentionPolicy
+            Resource: '*'
+        PolicyName: RunnerInstanceLogsPolicy
       Tags:
       - Key: nuon_runner_id
         Value:
@@ -114,20 +158,65 @@ Resources:
           Fn::Sub: ${RunnerId}-runner-instance
     Type: AWS::IAM::Role
 
-  # this is required to allow the runner ASG instances to access their metadata/tags
-  RunnerInstanceRoleCloudWatchLogPolicy:
+  # this is required to allow the runner ASG instances to access their own metadata/tags
+  # (the init script reads nuon_runner_id / nuon_runner_api_url off its own instance).
+  #
+  # ec2:DescribeTags cannot be narrowed: it supports neither resource-level ARNs
+  # nor the ec2:ResourceTag condition key, so "*" is the only valid resource. The
+  # read is scoped in practice by the --filters on the instance's own id, and the
+  # action is list-only.
+  #
+  # NOTE: the logical id here was renamed away from the original
+  # RunnerInstanceRoleCloudWatchLogPolicy, which never described what it did.
+  # CloudFormation treats a logical id rename as create-new-then-delete-old, and
+  # an AWS::IAM::Policy is identified by (PolicyName, attached role) -- so the
+  # PolicyName has to change alongside the logical id, or the new resource
+  # collides with the old one that has not been deleted yet.
+  RunnerInstanceRoleEC2InstanceMetadataPolicy:
     Type: AWS::IAM::Policy
     Properties:
       PolicyName:
-        Fn::Sub: ${RunnerId}-runner-instance-metadata
+        Fn::Sub: ${RunnerId}-runner-ec2-instance-metadata
       Roles:
       - Ref: RunnerInstanceRole
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-        - Effect: Allow
+        - Sid: ReadOwnInstanceTags
+          Effect: Allow
           Action:
           - ec2:DescribeTags
+          Resource: "*"
+
+  # Self-lifecycle: the runner rolls itself via an instance refresh on its own
+  # ASG. Kept as a separate AWS::IAM::Policy because it needs a Ref to the ASG
+  # (whose name CloudFormation generates) to build the ARN scope.
+  #
+  # The autoscaling Describe* actions do not support resource-level permissions,
+  # so they sit in their own "*" statement; the mutating action is scoped to this
+  # stack's ASG only.
+  RunnerInstanceRoleSelfLifecyclePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName:
+        Fn::Sub: ${RunnerId}-runner-self-lifecycle
+      Roles:
+      - Ref: RunnerInstanceRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Sid: RefreshOwnAutoScalingGroup
+          Effect: Allow
+          Action:
+          - autoscaling:StartInstanceRefresh
+          - autoscaling:DescribeInstanceRefreshes
+          Resource:
+            Fn::Sub: arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${RunnerAutoScalingGroup}
+        - Sid: DescribeAutoScalingState
+          Effect: Allow
+          Action:
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
           Resource: "*"
   RunnerLaunchTemplate:
     Properties:


### PR DESCRIPTION
The runner permissions are scoped down a bit to:

1. Assume the default and custom roles. This is done using a naming
   convention as opposed to a tag. see runner/asg/stack.yaml:116. in the
   near future, it may be worth exploring a tagging-based condition on
   the permisson and enforcing the tag in the nuon control plane.
1. Explicitly allow Instance Refresh on self
1. Explictly allow creating and writing its log groups
1. Explictly deny deleting its log groups
